### PR TITLE
feat(mybatis): 优化 Mapper.xml 文件的热更新机制

### DIFF
--- a/debug-tools-hotswap/debug-tools-hotswap-plugin/debug-tools-hotswap-mybatis-plugin/src/main/java/io/github/future0923/debug/tools/hotswap/core/plugin/mybatis/MyBatisPlugin.java
+++ b/debug-tools-hotswap/debug-tools-hotswap-plugin/debug-tools-hotswap-mybatis-plugin/src/main/java/io/github/future0923/debug/tools/hotswap/core/plugin/mybatis/MyBatisPlugin.java
@@ -27,6 +27,7 @@ import io.github.future0923.debug.tools.hotswap.core.plugin.mybatis.patch.Dynami
 import io.github.future0923.debug.tools.hotswap.core.plugin.mybatis.patch.IBatisPatcher;
 import io.github.future0923.debug.tools.hotswap.core.plugin.mybatis.patch.MyBatisPlusPatcher;
 import io.github.future0923.debug.tools.hotswap.core.plugin.mybatis.patch.MyBatisSpringPatcher;
+import io.github.future0923.debug.tools.hotswap.core.plugin.mybatis.reload.MyBatisSpringResourceManager;
 import io.github.future0923.debug.tools.hotswap.core.plugin.mybatis.utils.MyBatisUtils;
 import org.xml.sax.SAXException;
 
@@ -97,9 +98,17 @@ public class MyBatisPlugin {
         if (!MyBatisUtils.isMyBatisSpring(appClassLoader) && !MyBatisUtils.isMyBatisPlus(appClassLoader)) {
             return;
         }
-        if ((FileEvent.CREATE.equals(fileEvent) && MyBatisUtils.isMapperXml(url.getPath()))
-                || ((FileEvent.MODIFY.equals(fileEvent) && configurationMap.containsKey(url.getPath())))) {
+        if ((FileEvent.CREATE.equals(fileEvent) && MyBatisUtils.isMapperXml(url.getPath()) && isInMapperLocations(url))
+                || (FileEvent.MODIFY.equals(fileEvent) && configurationMap.containsKey(url.getPath()))) {
             scheduler.scheduleCommand(new MyBatisSpringXmlReloadCommand(appClassLoader, url), 1000);
         }
+    }
+
+    private static boolean isInMapperLocations(URL url) {
+        if (MyBatisSpringResourceManager.isInMapperLocations(url.getPath())) {
+            return true;
+        }
+        logger.info("{} is not in mybatis.mapper-locations or mybatis-plus.mapper-locations", url.getPath());
+        return false;
     }
 }

--- a/debug-tools-hotswap/debug-tools-hotswap-plugin/debug-tools-hotswap-mybatis-plugin/src/main/java/io/github/future0923/debug/tools/hotswap/core/plugin/mybatis/patch/MyBatisSpringPatcher.java
+++ b/debug-tools-hotswap/debug-tools-hotswap-plugin/debug-tools-hotswap-mybatis-plugin/src/main/java/io/github/future0923/debug/tools/hotswap/core/plugin/mybatis/patch/MyBatisSpringPatcher.java
@@ -84,12 +84,15 @@ public class MyBatisSpringPatcher {
     }
 
     /**
-     * MyBatisProperties.resolveMapperLocations 插桩，获取mapperLocations
+     * MybatisProperties.resolveMapperLocations 插桩，获取mapperLocations
+     * <p>
+     *     Spring+Mybatis工程中：限制加载的Mapper.xml必须为<code>mybatis.mapper-locations</code>配置的文件
+     * </p>
      *
      * @param ctClass   ctClass
      * @param classPool classPool
      */
-    @OnClassLoadEvent(classNameRegexp = "org.mybatis.spring.boot.autoconfigure.MyBatisProperties|com.baomidou.mybatisplus.autoconfigure.MybatisProperties")
+    @OnClassLoadEvent(classNameRegexp = "org.mybatis.spring.boot.autoconfigure.MybatisProperties")
     public static void patchMapperLocations(CtClass ctClass, ClassPool classPool) {
         try {
             CtMethod resolveMapperLocations = ctClass.getDeclaredMethod("resolveMapperLocations");

--- a/debug-tools-hotswap/debug-tools-hotswap-plugin/debug-tools-hotswap-mybatis-plugin/src/main/java/io/github/future0923/debug/tools/hotswap/core/plugin/mybatis/patch/MyBatisSpringPatcher.java
+++ b/debug-tools-hotswap/debug-tools-hotswap-plugin/debug-tools-hotswap-mybatis-plugin/src/main/java/io/github/future0923/debug/tools/hotswap/core/plugin/mybatis/patch/MyBatisSpringPatcher.java
@@ -83,6 +83,24 @@ public class MyBatisSpringPatcher {
         }
     }
 
+    /**
+     * MyBatisProperties.resolveMapperLocations 插桩，获取mapperLocations
+     *
+     * @param ctClass   ctClass
+     * @param classPool classPool
+     */
+    @OnClassLoadEvent(classNameRegexp = "org.mybatis.spring.boot.autoconfigure.MyBatisProperties|com.baomidou.mybatisplus.autoconfigure.MybatisProperties")
+    public static void patchMapperLocations(CtClass ctClass, ClassPool classPool) {
+        try {
+            CtMethod resolveMapperLocations = ctClass.getDeclaredMethod("resolveMapperLocations");
+            resolveMapperLocations.insertAfter("{" +
+                    MyBatisSpringResourceManager.class.getName() + ".addMapperLocations(this.mapperLocations);" +
+                    "}");
+        } catch (Throwable e) {
+            logger.error("patchMapperLocations err", e);
+        }
+    }
+
     @OnClassLoadEvent(classNameRegexp = "org.mybatis.spring.SqlSessionFactoryBean")
     public static void patchSqlSessionFactoryBean(CtClass ctClass, ClassPool classPool) throws Exception {
         logger.debug("org.mybatis.spring.SqlSessionFactoryBean patched.");

--- a/debug-tools-hotswap/debug-tools-hotswap-plugin/debug-tools-hotswap-mybatis-plugin/src/main/java/io/github/future0923/debug/tools/hotswap/core/plugin/mybatis/reload/MyBatisSpringResourceManager.java
+++ b/debug-tools-hotswap/debug-tools-hotswap-plugin/debug-tools-hotswap-mybatis-plugin/src/main/java/io/github/future0923/debug/tools/hotswap/core/plugin/mybatis/reload/MyBatisSpringResourceManager.java
@@ -29,6 +29,7 @@ import org.mybatis.spring.mapper.ClassPathMapperScanner;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 
+import java.io.File;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -140,7 +141,8 @@ public class MyBatisSpringResourceManager {
             try {
                 Resource[] resources = resourcePatternResolver.getResources(mapperLocation);
                 for (Resource resource : resources) {
-                    if (resource.getFile().getAbsolutePath().equals(absolutePath)) {
+                    // 使用File进行比较，避免windows上absolutePath路径格式不一致导致判断错误
+                    if (resource.getFile().equals(new File(absolutePath))) {
                         return true;
                     }
                 }


### PR DESCRIPTION
- MyBatisSpringResourceManager保存Mapper文件的扫描路径（spring工程），用于管理 Mapper.xml 文件的扫描路径
- 在 MyBatisPlugin 中增加对 Mapper.xml 文件是否在配置路径中的检查
- 在 MyBatisSpringPatcher 中添加对 MyBatisProperties.resolveMapperLocations 方法的插桩，获取 mapperLocations
- 优化了 Mapper.xml 文件的加载逻辑，只加载在配置路径中的文件