### PR TITLE
feat(idea): 优化hotswap的启动方式 

### DIFF
--- a/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/action/HotswapDebugAction.java
+++ b/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/action/HotswapDebugAction.java
@@ -39,13 +39,13 @@ public class HotswapDebugAction extends ExecutorAction {
     protected void update(@NotNull AnActionEvent e, boolean running) {
         Presentation presentation = e.getPresentation();
         if (running) {
-            presentation.setText("Rerun HotswapDebug");
-            presentation.setDescription("Rerun 'HotswapDebug' with DebugTools");
+            presentation.setText("Rerun DebugTools Hotswap");
+            presentation.setDescription("Rerun hotswap with DebugTools");
             presentation.setIcon(DebugToolsIcons.Hotswap.Off);
         }
         else {
-            presentation.setText("Run HotswapDebug");
-            presentation.setDescription("Run 'HotswapDebug' with DebugTools");
+            presentation.setText("Run DebugTools Hotswap");
+            presentation.setDescription("Run hotswap with DebugTools");
             presentation.setIcon(DebugToolsIcons.Hotswap.Off);
         }
     }

--- a/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/action/HotswapDebugAction.java
+++ b/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/action/HotswapDebugAction.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024-2025 the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.github.future0923.debug.tools.idea.action;
+
+import com.intellij.execution.Executor;
+import com.intellij.execution.dashboard.actions.ExecutorAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.Presentation;
+import io.github.future0923.debug.tools.idea.runner.HotswapDebugExecutor;
+import io.github.future0923.debug.tools.idea.utils.DebugToolsIcons;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Hotswap with DebugTools
+ */
+public class HotswapDebugAction extends ExecutorAction {
+
+
+    @Override
+    protected Executor getExecutor() {
+        return HotswapDebugExecutor.getRunExecutorInstance();
+    }
+
+    @Override
+    protected void update(@NotNull AnActionEvent e, boolean running) {
+        Presentation presentation = e.getPresentation();
+        if (running) {
+            presentation.setText("Rerun HotswapDebug");
+            presentation.setDescription("Rerun 'HotswapDebug' with DebugTools");
+            presentation.setIcon(DebugToolsIcons.Hotswap.Off);
+        }
+        else {
+            presentation.setText("Run HotswapDebug");
+            presentation.setDescription("Run 'HotswapDebug' with DebugTools");
+            presentation.setIcon(DebugToolsIcons.Hotswap.Off);
+        }
+    }
+}

--- a/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/patcher/DebugToolsJavaProgramPatcher.java
+++ b/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/patcher/DebugToolsJavaProgramPatcher.java
@@ -93,7 +93,7 @@ public class DebugToolsJavaProgramPatcher extends JavaProgramPatcher {
         String agentPath = settingState.loadAgentPath(project);
         Boolean traceSql = settingState.getTraceMethodDTO() != null && BooleanUtil.isTrue(settingState.getTraceMethodDTO().getTraceMethod()) && BooleanUtil.isTrue(settingState.getTraceMethodDTO().getTraceSQL());
         // 根据执行器判断是否使用hotswap
-        boolean hotswap = HotswapDebugExecutor.EXECUTOR_ID.equals(executor.getId()) || settingState.getHotswap();
+        boolean hotswap = HotswapDebugExecutor.EXECUTOR_ID.equals(executor.getId());
         if (!PrintSqlType.NO.equals(settingState.getPrintSql())
                 || hotswap
                 || traceSql) {

--- a/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/patcher/DebugToolsJavaProgramPatcher.java
+++ b/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/patcher/DebugToolsJavaProgramPatcher.java
@@ -30,6 +30,7 @@ import io.github.future0923.debug.tools.base.hutool.core.io.FileUtil;
 import io.github.future0923.debug.tools.base.hutool.core.util.BooleanUtil;
 import io.github.future0923.debug.tools.base.utils.DebugToolsExecUtils;
 import io.github.future0923.debug.tools.base.utils.DebugToolsFileUtils;
+import io.github.future0923.debug.tools.idea.runner.HotswapDebugExecutor;
 import io.github.future0923.debug.tools.idea.setting.DebugToolsSettingState;
 import io.github.future0923.debug.tools.idea.utils.DcevmUtils;
 import io.github.future0923.debug.tools.idea.utils.DebugToolsNotifierUtil;
@@ -52,26 +53,26 @@ public class DebugToolsJavaProgramPatcher extends JavaProgramPatcher {
         if (project == null) {
             return;
         }
-        applyForConfiguration(configuration, javaParameters, project);
+        applyForConfiguration(executor, configuration, javaParameters, project);
     }
 
     private boolean isMavenAndGrade(RunProfile configuration, JavaParameters javaParameters) {
-        if (configuration.getClass().getName().equals("org.jetbrains.idea.maven.execution.MavenRunConfiguration")) {
+        if ("org.jetbrains.idea.maven.execution.MavenRunConfiguration".equals(configuration.getClass().getName())) {
             return true;
         }
-        if (configuration.getClass().getName().equals("org.jetbrains.plugins.gradle.service.execution.GradleRunConfiguration")) {
+        if ("org.jetbrains.plugins.gradle.service.execution.GradleRunConfiguration".equals(configuration.getClass().getName())) {
             return true;
         }
-        if (javaParameters.getMainClass().equals("org.codehaus.classworlds.Launcher")) {
+        if ("org.codehaus.classworlds.Launcher".equals(javaParameters.getMainClass())) {
             return true;
         }
-        if (javaParameters.getMainClass().equals("org.codehaus.plexus.classworlds.launcher.Launcher")) {
+        if ("org.codehaus.plexus.classworlds.launcher.Launcher".equals(javaParameters.getMainClass())) {
             return true;
         }
         return false;
     }
 
-    private void applyForConfiguration(RunProfile configuration, JavaParameters javaParameters, Project project) {
+    private void applyForConfiguration(Executor executor, RunProfile configuration, JavaParameters javaParameters, Project project) {
         log.debug("Applying HotSwapAgent to configuration " + (configuration != null ? configuration.getName() : ""));
         String jdkPath;
         try {
@@ -91,12 +92,14 @@ public class DebugToolsJavaProgramPatcher extends JavaProgramPatcher {
         DebugToolsSettingState settingState = DebugToolsSettingState.getInstance(project);
         String agentPath = settingState.loadAgentPath(project);
         Boolean traceSql = settingState.getTraceMethodDTO() != null && BooleanUtil.isTrue(settingState.getTraceMethodDTO().getTraceMethod()) && BooleanUtil.isTrue(settingState.getTraceMethodDTO().getTraceSQL());
+        // 根据执行器判断是否使用hotswap
+        boolean hotswap = HotswapDebugExecutor.EXECUTOR_ID.equals(executor.getId()) || settingState.getHotswap();
         if (!PrintSqlType.NO.equals(settingState.getPrintSql())
-                || settingState.getHotswap()
+                || hotswap
                 || traceSql) {
             AgentArgs agentArgs = new AgentArgs();
             agentArgs.setServer(Boolean.FALSE.toString());
-            if (settingState.getHotswap()) {
+            if (hotswap) {
                 //ProjectRootManager rootManager = ProjectRootManager.getInstance(project);
                 //rootManager.getProjectSdk();
                 if (jdkVersion.startsWith("17") || jdkVersion.startsWith("21")) {

--- a/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/runner/HotswapDebugExecutor.java
+++ b/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/runner/HotswapDebugExecutor.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2024-2025 the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.github.future0923.debug.tools.idea.runner;
+
+import com.intellij.execution.Executor;
+import com.intellij.execution.ExecutorRegistry;
+import com.intellij.openapi.util.NlsActions;
+import io.github.future0923.debug.tools.idea.utils.DebugToolsIcons;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+
+public class HotswapDebugExecutor extends Executor {
+
+    public static final String EXECUTOR_ID = "DebugTools Debug Executor";
+
+    @Override
+    public @NotNull String getToolWindowId() {
+        return getId();
+    }
+
+    @Override
+    public @NotNull Icon getToolWindowIcon() {
+        return getIcon();
+    }
+
+    @Override
+    public @NotNull Icon getIcon() {
+        return DebugToolsIcons.Hotswap.Off;
+    }
+
+    @Override
+    public Icon getDisabledIcon() {
+        return DebugToolsIcons.Hotswap.Off;
+    }
+
+    @Override
+    public @NlsActions.ActionDescription String getDescription() {
+        return "Debug with DebugTools";
+    }
+
+    @Override
+    public @NotNull @NlsActions.ActionText String getActionName() {
+        return EXECUTOR_ID;
+    }
+
+    @Override
+    public @NotNull @NonNls String getId() {
+        return EXECUTOR_ID;
+    }
+
+    @Override
+    public @NotNull @Nls(capitalization = Nls.Capitalization.Title) String getStartActionText() {
+        return "Hotswap Debug: ";
+    }
+
+    @Override
+    public @NonNls String getContextActionId() {
+        return getId() + "-no-context-action-id";
+    }
+
+    @Override
+    public @NonNls String getHelpId() {
+        return null;
+    }
+
+    public static Executor getRunExecutorInstance() {
+        return ExecutorRegistry.getInstance().getExecutorById(EXECUTOR_ID);
+    }
+}

--- a/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/runner/HotswapDebugExecutor.java
+++ b/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/runner/HotswapDebugExecutor.java
@@ -19,6 +19,8 @@ package io.github.future0923.debug.tools.idea.runner;
 import com.intellij.execution.Executor;
 import com.intellij.execution.ExecutorRegistry;
 import com.intellij.openapi.util.NlsActions;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.util.text.TextWithMnemonic;
 import io.github.future0923.debug.tools.idea.utils.DebugToolsIcons;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NonNls;
@@ -53,7 +55,7 @@ public class HotswapDebugExecutor extends Executor {
 
     @Override
     public @NlsActions.ActionDescription String getDescription() {
-        return "Debug with DebugTools";
+        return "Hotswap debug with DebugTools";
     }
 
     @Override
@@ -68,7 +70,13 @@ public class HotswapDebugExecutor extends Executor {
 
     @Override
     public @NotNull @Nls(capitalization = Nls.Capitalization.Title) String getStartActionText() {
-        return "Hotswap Debug: ";
+        return "Hotswap with DebugTools";
+    }
+
+    @Override
+    public @NotNull @Nls(capitalization = Nls.Capitalization.Title) String getStartActionText(@NotNull String configurationName) {
+        String configName = StringUtil.isEmpty(configurationName) ? "" : " '" + shortenNameIfNeeded(configurationName) + "'";
+        return TextWithMnemonic.parse("Hotswap").append(configName).append(" with DebugTools").toString();
     }
 
     @Override

--- a/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/runner/HotswapDebugRunner.java
+++ b/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/runner/HotswapDebugRunner.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024-2025 the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.github.future0923.debug.tools.idea.runner;
+
+import com.intellij.debugger.impl.GenericDebuggerRunner;
+import com.intellij.execution.configurations.*;
+import org.jetbrains.annotations.NotNull;
+
+public class HotswapDebugRunner extends GenericDebuggerRunner {
+    public static final String RUNNER_ID = "DEBUG_TOOLS_DEBUG_RUNNER";
+
+    @Override
+    public boolean canRun(@NotNull String executorId, @NotNull RunProfile profile) {
+        return executorId.equals(HotswapDebugExecutor.EXECUTOR_ID) && profile instanceof ModuleRunProfile
+                && !(profile instanceof RunConfigurationWithSuppressedDefaultDebugAction);
+    }
+
+
+    @Override
+    public @NotNull String getRunnerId() {
+        return RUNNER_ID;
+    }
+}

--- a/debug-tools-idea/src/main/resources/META-INF/plugin.xml
+++ b/debug-tools-idea/src/main/resources/META-INF/plugin.xml
@@ -211,14 +211,14 @@
                 text="Search Http Url" description="Search http url and goto it">
             <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt N"/>
         </action>
-        <group id="DebugToolsHotSwap">
+        <!--<group id="DebugToolsHotSwap">
             <add-to-group group-id="ToolbarRunGroup" anchor="after"
                           relative-to-action="MoreRunToolbarActions"/>
             <add-to-group group-id="RunToolbarMainActionGroup" anchor="after"
                           relative-to-action="MoreRunToolbarActions"/>
             <action id="HotSwapSwitchAction"
                     class="io.github.future0923.debug.tools.idea.action.HotSwapSwitchAction"/>
-        </group>
+        </group>-->
         <action id="DebugTools.CopyAsJson" class="io.github.future0923.debug.tools.idea.action.CopyAsJsonAction"
                 text="Copy as JSON">
             <add-to-group group-id="XDebugger.ValueGroup" anchor="before" relative-to-action="XDebugger.CopyValue"/>

--- a/debug-tools-idea/src/main/resources/META-INF/plugin.xml
+++ b/debug-tools-idea/src/main/resources/META-INF/plugin.xml
@@ -151,6 +151,9 @@
         <!--json编辑器代码导航-->
         <lang.directNavigationProvider
                 implementation="io.github.future0923.debug.tools.idea.navigation.DebugToolsJsonEditorDirectNavigationProvider"/>
+        <!-- 注册HotswapDebugRunner和HotswapDebugExecutor -->
+        <programRunner implementation="io.github.future0923.debug.tools.idea.runner.HotswapDebugRunner"/>
+        <executor implementation="io.github.future0923.debug.tools.idea.runner.HotswapDebugExecutor"/>
     </extensions>
 
     <actions>
@@ -220,6 +223,11 @@
                 text="Copy as JSON">
             <add-to-group group-id="XDebugger.ValueGroup" anchor="before" relative-to-action="XDebugger.CopyValue"/>
 
+        </action>
+        <action id="io.github.future0923.debug.tools.idea.action.HotswapDebugAction"
+                class="io.github.future0923.debug.tools.idea.action.HotswapDebugAction" popup="true">
+            <!-- 添加到services -->
+            <add-to-group group-id="RunDashboardContentToolbar" anchor="after" relative-to-action="RunDashboard.Stop"/>
         </action>
     </actions>
 


### PR DESCRIPTION
#57 

- 新增 HotswapDebugExecutor 和 HotswapDebugRunner 类以支持Run Configuration

<img width="595" height="230" alt="image" src="https://github.com/user-attachments/assets/f118db73-e6a7-4c45-b37f-2075bb83babe" />

- 新增 HotswapDebugAction 并注册到 RunDashboardContentToolbar ，以支持在 services 界面快速启动

<img width="803" height="374" alt="image" src="https://github.com/user-attachments/assets/2ce96450-ea2b-49d6-9484-0f44ad5d3bf3" />
