### PR TITLE
self/main-fix-easyExcel-export

### DIFF
--- a/debug-tools-hotswap/debug-tools-hotswap-plugin/debug-tools-hotswap-easyexcel-plugin/src/main/java/io/github/future0923/debug/tools/hotswap/core/plugin/easyexcel/EasyExcelPlugin.java
+++ b/debug-tools-hotswap/debug-tools-hotswap-plugin/debug-tools-hotswap-easyexcel-plugin/src/main/java/io/github/future0923/debug/tools/hotswap/core/plugin/easyexcel/EasyExcelPlugin.java
@@ -102,42 +102,54 @@ public class EasyExcelPlugin {
         CtMethod getHeadMap = ctClass.getDeclaredMethod("getHeadMap");
         String beforeHandler =
                 "if (this.headClazz != null) {" +
-                "   this.headMap.clear();" +
-                "   this.initColumnProperties(this.holder);" +
-                "   this.initHeadRowNumber();" +
-                "   com.alibaba.excel.annotation.write.style.ColumnWidth parentColumnWidth = this.headClazz.getAnnotation(com.alibaba.excel.annotation.write.style.ColumnWidth.class);" +
-                "   com.alibaba.excel.annotation.write.style.HeadStyle parentHeadStyle = this.headClazz.getAnnotation(com.alibaba.excel.annotation.write.style.HeadStyle.class);" +
-                "   com.alibaba.excel.annotation.write.style.HeadFontStyle parentHeadFontStyle = this.headClazz.getAnnotation(com.alibaba.excel.annotation.write.style.HeadFontStyle.class);" +
-                "   java.util.Set entrySet = this.headMap.entrySet();" +
-                "   java.util.Iterator iterator = entrySet.iterator();" +
-                "   while (iterator.hasNext()) {" +
-                "       Object obj = iterator.next();" +
-                "       java.util.Map.Entry entry = (java.util.Map.Entry) obj;" +
-                "       com.alibaba.excel.metadata.Head headData = (com.alibaba.excel.metadata.Head) entry.getValue();" +
-                "       if (headData == null) continue;" +
-                "       java.lang.reflect.Field field = headData.getField();" +
-
-                "       com.alibaba.excel.annotation.write.style.ColumnWidth columnWidth = null;" +
-                "       if (field != null) columnWidth = field.getAnnotation(com.alibaba.excel.annotation.write.style.ColumnWidth.class);" +
-                "       if (columnWidth == null) columnWidth = parentColumnWidth;" +
-
-                "       com.alibaba.excel.annotation.write.style.HeadStyle headStyle = null;" +
-                "       if (field != null) headStyle = field.getAnnotation(com.alibaba.excel.annotation.write.style.HeadStyle.class);" +
-                "       if (headStyle == null) headStyle = parentHeadStyle;" +
-
-                "       com.alibaba.excel.annotation.write.style.HeadFontStyle headFontStyle = null;" +
-                "       if (field != null) headFontStyle = field.getAnnotation(com.alibaba.excel.annotation.write.style.HeadFontStyle.class);" +
-                "       if (headFontStyle == null) headFontStyle = parentHeadFontStyle;" +
-
-                "       com.alibaba.excel.annotation.write.style.ContentLoopMerge contentLoopMerge = null;" +
-                "       if (field != null) contentLoopMerge = field.getAnnotation(com.alibaba.excel.annotation.write.style.ContentLoopMerge.class);" +
-
-                "       headData.setColumnWidthProperty(com.alibaba.excel.metadata.property.ColumnWidthProperty.build(columnWidth));" +
-                "       headData.setHeadStyleProperty(com.alibaba.excel.metadata.property.StyleProperty.build(headStyle));" +
-                "       headData.setHeadFontProperty(com.alibaba.excel.metadata.property.FontProperty.build(headFontStyle));" +
-                "       headData.setLoopMergeProperty(com.alibaba.excel.metadata.property.LoopMergeProperty.build(contentLoopMerge));" +
-                "   }" +
+                "    this.headMap.clear();" +
+                "    this.initColumnProperties(this.holder);" +
+                "    this.initHeadRowNumber();" +
+                "    com.alibaba.excel.annotation.write.style.ColumnWidth parentColumnWidth = this.headClazz.getAnnotation(com.alibaba.excel.annotation.write.style.ColumnWidth.class);" +
+                "    com.alibaba.excel.annotation.write.style.HeadStyle parentHeadStyle = this.headClazz.getAnnotation(com.alibaba.excel.annotation.write.style.HeadStyle.class);" +
+                "    com.alibaba.excel.annotation.write.style.HeadFontStyle parentHeadFontStyle = this.headClazz.getAnnotation(com.alibaba.excel.annotation.write.style.HeadFontStyle.class);" +
+                "    java.util.Set entrySet = this.headMap.entrySet();" +
+                "    java.util.Iterator iterator = entrySet.iterator();" +
+                "    while (iterator.hasNext()) {" +
+                "        Object obj = iterator.next();" +
+                "        java.util.Map.Entry entry = (java.util.Map.Entry) obj;" +
+                "        com.alibaba.excel.metadata.Head headData = (com.alibaba.excel.metadata.Head) entry.getValue();" +
+                "        if (headData == null) {" +
+                "            continue;" +
+                "        }" +
+                "        java.lang.reflect.Field field = headData.getField();" +
+                "        com.alibaba.excel.annotation.write.style.ColumnWidth columnWidth = null;" +
+                "        if (field != null) {" +
+                "            columnWidth = field.getAnnotation(com.alibaba.excel.annotation.write.style.ColumnWidth.class);" +
+                "        }" +
+                "        if (columnWidth == null) {" +
+                "            columnWidth = parentColumnWidth;" +
+                "        }" +
+                "        com.alibaba.excel.annotation.write.style.HeadStyle headStyle = null;" +
+                "        if (field != null) {" +
+                "            headStyle = field.getAnnotation(com.alibaba.excel.annotation.write.style.HeadStyle.class);" +
+                "        }" +
+                "        if (headStyle == null) {" +
+                "            headStyle = parentHeadStyle;" +
+                "        }" +
+                "        com.alibaba.excel.annotation.write.style.HeadFontStyle headFontStyle = null;" +
+                "        if (field != null) {" +
+                "            headFontStyle = field.getAnnotation(com.alibaba.excel.annotation.write.style.HeadFontStyle.class);" +
+                "        }" +
+                "        if (headFontStyle == null) {" +
+                "            headFontStyle = parentHeadFontStyle;" +
+                "        }" +
+                "        com.alibaba.excel.annotation.write.style.ContentLoopMerge contentLoopMerge = null;" +
+                "        if (field != null) {" +
+                "            contentLoopMerge = field.getAnnotation(com.alibaba.excel.annotation.write.style.ContentLoopMerge.class);" +
+                "        }" +
+                "        headData.setColumnWidthProperty(com.alibaba.excel.metadata.property.ColumnWidthProperty.build(columnWidth));" +
+                "        headData.setHeadStyleProperty(com.alibaba.excel.metadata.property.StyleProperty.build(headStyle));" +
+                "        headData.setHeadFontProperty(com.alibaba.excel.metadata.property.FontProperty.build(headFontStyle));" +
+                "        headData.setLoopMergeProperty(com.alibaba.excel.metadata.property.LoopMergeProperty.build(contentLoopMerge));" +
+                "    }" +
                 "}";
+
 
         getHeadMap.insertBefore("{" + beforeHandler + "}");
         logger.info("patch easy excel ExcelHeadProperty success");

--- a/debug-tools-hotswap/debug-tools-hotswap-plugin/debug-tools-hotswap-easyexcel-plugin/src/main/java/io/github/future0923/debug/tools/hotswap/core/plugin/easyexcel/EasyExcelPlugin.java
+++ b/debug-tools-hotswap/debug-tools-hotswap-plugin/debug-tools-hotswap-easyexcel-plugin/src/main/java/io/github/future0923/debug/tools/hotswap/core/plugin/easyexcel/EasyExcelPlugin.java
@@ -100,13 +100,46 @@ public class EasyExcelPlugin {
                     "}");
         }
         CtMethod getHeadMap = ctClass.getDeclaredMethod("getHeadMap");
-        getHeadMap.insertBefore("{" +
-                "   if (this.headClazz != null) {" +
-                "       this.headMap.clear();" +
-                "       this.initColumnProperties(this.holder);" +
-                "       this.initHeadRowNumber();" +
+        String beforeHandler =
+                "if (this.headClazz != null) {" +
+                "   this.headMap.clear();" +
+                "   this.initColumnProperties(this.holder);" +
+                "   this.initHeadRowNumber();" +
+                "   com.alibaba.excel.annotation.write.style.ColumnWidth parentColumnWidth = this.headClazz.getAnnotation(com.alibaba.excel.annotation.write.style.ColumnWidth.class);" +
+                "   com.alibaba.excel.annotation.write.style.HeadStyle parentHeadStyle = this.headClazz.getAnnotation(com.alibaba.excel.annotation.write.style.HeadStyle.class);" +
+                "   com.alibaba.excel.annotation.write.style.HeadFontStyle parentHeadFontStyle = this.headClazz.getAnnotation(com.alibaba.excel.annotation.write.style.HeadFontStyle.class);" +
+                "   java.util.Set entrySet = this.headMap.entrySet();" +
+                "   java.util.Iterator iterator = entrySet.iterator();" +
+                "   while (iterator.hasNext()) {" +
+                "       Object obj = iterator.next();" +
+                "       java.util.Map.Entry entry = (java.util.Map.Entry) obj;" +
+                "       com.alibaba.excel.metadata.Head headData = (com.alibaba.excel.metadata.Head) entry.getValue();" +
+                "       if (headData == null) continue;" +
+                "       java.lang.reflect.Field field = headData.getField();" +
+
+                "       com.alibaba.excel.annotation.write.style.ColumnWidth columnWidth = null;" +
+                "       if (field != null) columnWidth = field.getAnnotation(com.alibaba.excel.annotation.write.style.ColumnWidth.class);" +
+                "       if (columnWidth == null) columnWidth = parentColumnWidth;" +
+
+                "       com.alibaba.excel.annotation.write.style.HeadStyle headStyle = null;" +
+                "       if (field != null) headStyle = field.getAnnotation(com.alibaba.excel.annotation.write.style.HeadStyle.class);" +
+                "       if (headStyle == null) headStyle = parentHeadStyle;" +
+
+                "       com.alibaba.excel.annotation.write.style.HeadFontStyle headFontStyle = null;" +
+                "       if (field != null) headFontStyle = field.getAnnotation(com.alibaba.excel.annotation.write.style.HeadFontStyle.class);" +
+                "       if (headFontStyle == null) headFontStyle = parentHeadFontStyle;" +
+
+                "       com.alibaba.excel.annotation.write.style.ContentLoopMerge contentLoopMerge = null;" +
+                "       if (field != null) contentLoopMerge = field.getAnnotation(com.alibaba.excel.annotation.write.style.ContentLoopMerge.class);" +
+
+                "       headData.setColumnWidthProperty(com.alibaba.excel.metadata.property.ColumnWidthProperty.build(columnWidth));" +
+                "       headData.setHeadStyleProperty(com.alibaba.excel.metadata.property.StyleProperty.build(headStyle));" +
+                "       headData.setHeadFontProperty(com.alibaba.excel.metadata.property.FontProperty.build(headFontStyle));" +
+                "       headData.setLoopMergeProperty(com.alibaba.excel.metadata.property.LoopMergeProperty.build(contentLoopMerge));" +
                 "   }" +
-                "}");
+                "}";
+
+        getHeadMap.insertBefore("{" + beforeHandler + "}");
         logger.info("patch easy excel ExcelHeadProperty success");
     }
 


### PR DESCRIPTION
## 问题描述
#98
## 问题原因
插件对 `EasyExcel` 的` ExcelHeadProperty `进行了增强，在调用 `getHeadMap()` 时会清空原有 headMap 并重新加载。
然而，表头样式 headStyle 是在其子类 `ExcelWriteHeadProperty` 的有参构造函数中初始化的，因此在重新加载 headMap 时样式信息会被丢失。
## 解决方案
在调用 `getHeadMap() `后，对表头样式 style 重新赋值