### PR TITLE
fix(deploy): idea本地编译时找不到编译后的文件 issue #132

### DIFF
--- a/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/ui/hotswap/HotDeployDialog.java
+++ b/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/ui/hotswap/HotDeployDialog.java
@@ -284,8 +284,8 @@ public class HotDeployDialog extends DialogWrapper {
                         log.error(DebugToolsBundle.message("dialog.error.output.directory"));
                         return;
                     }
-                    // 如果输出目录未刷新，则刷新它
-                    if (!allOutputs.contains(outputDirectory)) {
+                    // 如果当前输出目录已经收集过，跳过此目录
+                    if (allOutputs.contains(outputDirectory)) {
                         return;
                     }
                     allOutputs.add(outputDirectory);


### PR DESCRIPTION
热部署或热重载，编译方式选择"Local Intellij Idea"/"IntelliJ IDEA"，时报错“The content of the locally compiled class file was not obtained”“未获取到本地编译后的 class 文件内容”